### PR TITLE
Fix comments and add support for attached comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [CoverageURL]: https://coveralls.io/github/coderaiser/estree-to-babel?branch=master
 [CoverageIMGURL]: https://coveralls.io/repos/coderaiser/estree-to-babel/badge.svg?branch=master&service=github
 
-Convert [estree](https://github.com/estree/estree) compatable `JavaScript AST` to `babel AST`.
+Convert [estree](https://github.com/estree/estree) compatible `JavaScript AST` to `babel AST`.
 
 To use parsers like:
 

--- a/lib/comments.js
+++ b/lib/comments.js
@@ -1,0 +1,59 @@
+'use strict';
+
+exports.convertNodeComments = convertNodeComments;
+exports.convertProgramComments = convertProgramComments;
+
+function convertNodeComments(node) {
+    const {comments} = node;
+    
+    if (!comments)
+        return;
+    
+    delete node.comments;
+    node.leadingComments = undefined;
+    node.trailingComments = undefined;
+    node.innerComments = undefined;
+    
+    for (const comment of comments) {
+        // Default to leading comment.
+        const group = getCommentGroup(comment);
+        
+        if (!node[group])
+            node[group] = [];
+        
+        delete comment.leading;
+        delete comment.trailing;
+        comment.type = getCommentType(comment);
+        node[group].push(comment);
+    }
+}
+
+function convertProgramComments(comments) {
+    return comments.map((comment) => {
+        comment.type = getCommentType(comment);
+        return comment;
+    });
+}
+
+function getCommentType({type}) {
+    if (type === 'Line')
+        return 'CommentLine';
+    
+    if (type === 'Block')
+        return 'CommentBlock';
+    
+    // Assume an unknown type, or that it’s already a Babel type.
+    return type;
+}
+
+function getCommentGroup({trailing, leading}) {
+    if (trailing)
+        return 'trailingComments';
+    
+    if (leading)
+        return 'leadingComments';
+    
+    // Dangling comments, such as `[/* a */]`.
+    return 'innerComments';
+}
+

--- a/lib/comments.js
+++ b/lib/comments.js
@@ -36,10 +36,11 @@ function getCommentType({type}) {
     if (type === 'Line')
         return 'CommentLine';
     
+    /* istanbul ignore else */
     if (type === 'Block')
         return 'CommentBlock';
     
-    // Assume an unknown type, or that it’s already a Babel type.
+    /* istanbul ignore next - Assume an unknown type, or that it’s already a Babel type. */
     return type;
 }
 

--- a/lib/comments.js
+++ b/lib/comments.js
@@ -1,9 +1,6 @@
 'use strict';
 
-exports.convertNodeComments = convertNodeComments;
-exports.convertProgramComments = convertProgramComments;
-
-function convertNodeComments(node) {
+module.exports.convertNodeComments = (node) => {
     const {comments} = node;
     
     if (!comments)
@@ -15,7 +12,6 @@ function convertNodeComments(node) {
     node.innerComments = undefined;
     
     for (const comment of comments) {
-        // Default to leading comment.
         const group = getCommentGroup(comment);
         
         if (!node[group])
@@ -26,14 +22,15 @@ function convertNodeComments(node) {
         comment.type = getCommentType(comment);
         node[group].push(comment);
     }
-}
+};
 
-function convertProgramComments(comments) {
-    return comments.map((comment) => {
+module.exports.convertProgramComments = (comments) => {
+    for (const comment of comments) {
         comment.type = getCommentType(comment);
-        return comment;
-    });
-}
+    }
+    
+    return comments;
+};
 
 function getCommentType({type}) {
     if (type === 'Line')

--- a/lib/estree-to-babel.js
+++ b/lib/estree-to-babel.js
@@ -42,6 +42,8 @@ module.exports = (node) => {
         exit(path) {
             const {node} = path;
             
+            setComments(node);
+            
             if (isObjectExpression(node))
                 return traverseObjectExpression(path.get('properties'));
         },
@@ -52,4 +54,34 @@ module.exports = (node) => {
 
 function setObjectProperty(node) {
     node.type = 'ObjectProperty';
+}
+
+function setComments(node) {
+    const {comments} = node;
+    
+    if (!comments)
+        return;
+    
+    delete node.comments;
+    node.leadingComments = undefined;
+    node.trailingComments = undefined;
+    node.innerComments = undefined;
+    
+    for (const comment of comments) {
+        // Default to leading comment.
+        const type = comment.trailing ? 'trailingComments' : !comment.leading ? 'innerComments' : 'leadingComments';
+        
+        if (comment.type === 'Line') {
+            comment.type = 'CommentLine';
+        } else if (comment.type === 'Block') {
+            comment.type = 'CommentBlock';
+        }
+        
+        if (!node[type])
+            node[type] = [];
+        
+        delete comment.leading;
+        delete comment.trailing;
+        node[type].push(comment);
+    }
 }

--- a/lib/estree-to-babel.js
+++ b/lib/estree-to-babel.js
@@ -9,6 +9,8 @@ const setClassPrivateMethod = require('./set-class-private-method');
 const setClassPrivateProperty = require('./set-class-private-property');
 const setClassPrivateName = require('./set-class-private-name');
 
+const {convertNodeComments} = require('./comments');
+
 const setLiteral = require('./set-literal');
 const getAST = require('./get-ast');
 
@@ -42,7 +44,7 @@ module.exports = (node) => {
         exit(path) {
             const {node} = path;
             
-            setComments(node);
+            convertNodeComments(node);
             
             if (isObjectExpression(node))
                 return traverseObjectExpression(path.get('properties'));
@@ -54,34 +56,4 @@ module.exports = (node) => {
 
 function setObjectProperty(node) {
     node.type = 'ObjectProperty';
-}
-
-function setComments(node) {
-    const {comments} = node;
-    
-    if (!comments)
-        return;
-    
-    delete node.comments;
-    node.leadingComments = undefined;
-    node.trailingComments = undefined;
-    node.innerComments = undefined;
-    
-    for (const comment of comments) {
-        // Default to leading comment.
-        const type = comment.trailing ? 'trailingComments' : !comment.leading ? 'innerComments' : 'leadingComments';
-        
-        if (comment.type === 'Line') {
-            comment.type = 'CommentLine';
-        } else if (comment.type === 'Block') {
-            comment.type = 'CommentBlock';
-        }
-        
-        if (!node[type])
-            node[type] = [];
-        
-        delete comment.leading;
-        delete comment.trailing;
-        node[type].push(comment);
-    }
 }

--- a/lib/get-ast.js
+++ b/lib/get-ast.js
@@ -16,10 +16,19 @@ module.exports = (node) => {
             ...program,
             directives: [],
         },
-        comments,
+        comments: comments.map(transformComment),
         tokens,
     };
     
     return ast;
 };
 
+function transformComment(comment) {
+    if (comment.type === 'Line') {
+        comment.type = 'CommentLine';
+    } else if (comment.type === 'Block') {
+        comment.type = 'CommentBlock';
+    }
+    
+    return comment;
+}

--- a/lib/get-ast.js
+++ b/lib/get-ast.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {convertProgramComments} = require('./comments');
+
 module.exports = (node) => {
     if (node.type === 'File')
         return node;
@@ -16,19 +18,9 @@ module.exports = (node) => {
             ...program,
             directives: [],
         },
-        comments: comments.map(transformComment),
+        comments: convertProgramComments(comments),
         tokens,
     };
     
     return ast;
 };
-
-function transformComment(comment) {
-    if (comment.type === 'Line') {
-        comment.type = 'CommentLine';
-    } else if (comment.type === 'Block') {
-        comment.type = 'CommentBlock';
-    }
-    
-    return comment;
-}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-putout": "^6.8.1",
     "espree": "^7.2.0",
+    "estree-util-attach-comments": "^1.0.0",
     "madrun": "^8.0.1",
     "nodemon": "^2.0.2",
     "nyc": "^15.0.0",

--- a/test/estree-to-babel.js
+++ b/test/estree-to-babel.js
@@ -9,6 +9,7 @@ const {
 const {extend} = require('supertape');
 const espree = require('espree');
 const babel = require('@babel/parser');
+const attachComments = require('estree-util-attach-comments');
 
 const estreeToBabel = require('..');
 
@@ -78,6 +79,7 @@ const fixture = {
         boolLiteral: readJSON('bool-literal.json'),
         regexpLiteral: readJSON('regexp-literal.json'),
         comments: readJSON('comments.json'),
+        commentsAttached: readJSON('comments-attached.json'),
         classMethod: readJSON('class-method.json'),
         classPrivateMethod: readJSON('class-private-method.json'),
         classPrivateProperty: readJSON('class-private-property.json'),
@@ -93,6 +95,7 @@ const fixture = {
         boolLiteral: readJS('bool-literal.js'),
         regexpLiteral: readJS('regexp-literal.js'),
         comments: readJS('comments.js'),
+        commentsAttached: readJS('comments-attached.js'),
         strictMode: readJS('strict-mode.js'),
         classMethod: readJS('class-method.js'),
         classPrivateMethod: readJS('class-private-method.js'),
@@ -177,6 +180,24 @@ test('estree-to-babel: comments', (t) => {
     update('comments', result);
     
     t.jsonEqual(result, fixture.ast.comments, 'should equal');
+    t.end();
+});
+
+test('estree-to-babel: attached comments', (t) => {
+    const ast = parse(fixture.js.commentsAttached);
+    const {comments} = ast;
+    
+    // Some estree parsers support only a top-level `comments` array.
+    // Others support only attached comment nodes.
+    // Babel has both.
+    attachComments(ast, comments);
+    ast.comments = comments;
+    
+    const result = estreeToBabel(ast);
+    
+    update('comments-attached', result);
+    
+    t.jsonEqual(result, fixture.ast.commentsAttached, 'should equal');
     t.end();
 });
 

--- a/test/fixture/comments-attached.js
+++ b/test/fixture/comments-attached.js
@@ -1,0 +1,4 @@
+// a
+const /* b */ t = /* c */ 'hello';
+
+const thing = [/* d */];

--- a/test/fixture/comments-attached.js
+++ b/test/fixture/comments-attached.js
@@ -3,4 +3,4 @@
 
 const thing = [/* g */];
 
-const other = {/* h */};
+const other = {/* h *//* i */};

--- a/test/fixture/comments-attached.js
+++ b/test/fixture/comments-attached.js
@@ -1,4 +1,6 @@
 // a
-const /* b */ t = /* c */ 'hello';
+/* b */ const /* c */ t = /* d */ 'hello' /* e */; // f
 
-const thing = [/* d */];
+const thing = [/* g */];
+
+const other = {/* h */};

--- a/test/fixture/comments-attached.json
+++ b/test/fixture/comments-attached.json
@@ -3,7 +3,7 @@
     "program": {
         "type": "Program",
         "start": 0,
-        "end": 113,
+        "end": 120,
         "loc": {
             "start": {
                 "line": 2,
@@ -11,7 +11,7 @@
             },
             "end": {
                 "line": 6,
-                "column": 24
+                "column": 31
             }
         },
         "body": [
@@ -259,7 +259,7 @@
             {
                 "type": "VariableDeclaration",
                 "start": 88,
-                "end": 112,
+                "end": 119,
                 "loc": {
                     "start": {
                         "line": 6,
@@ -267,14 +267,14 @@
                     },
                     "end": {
                         "line": 6,
-                        "column": 24
+                        "column": 31
                     }
                 },
                 "declarations": [
                     {
                         "type": "VariableDeclarator",
                         "start": 94,
-                        "end": 111,
+                        "end": 118,
                         "loc": {
                             "start": {
                                 "line": 6,
@@ -282,7 +282,7 @@
                             },
                             "end": {
                                 "line": 6,
-                                "column": 23
+                                "column": 30
                             }
                         },
                         "id": {
@@ -304,7 +304,7 @@
                         "init": {
                             "type": "ObjectExpression",
                             "start": 102,
-                            "end": 111,
+                            "end": 118,
                             "loc": {
                                 "start": {
                                     "line": 6,
@@ -312,7 +312,7 @@
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 23
+                                    "column": 30
                                 }
                             },
                             "properties": [],
@@ -334,6 +334,26 @@
                                         "end": {
                                             "line": 6,
                                             "column": 22
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "CommentBlock",
+                                    "value": " i ",
+                                    "start": 110,
+                                    "end": 117,
+                                    "range": [
+                                        110,
+                                        117
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 22
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 29
                                         }
                                     }
                                 }
@@ -505,6 +525,26 @@
                 "end": {
                     "line": 6,
                     "column": 22
+                }
+            }
+        },
+        {
+            "type": "CommentBlock",
+            "value": " i ",
+            "start": 110,
+            "end": 117,
+            "range": [
+                110,
+                117
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 22
+                },
+                "end": {
+                    "line": 6,
+                    "column": 29
                 }
             }
         }

--- a/test/fixture/comments-attached.json
+++ b/test/fixture/comments-attached.json
@@ -1,0 +1,301 @@
+{
+    "type": "File",
+    "program": {
+        "type": "Program",
+        "start": 0,
+        "end": 66,
+        "loc": {
+            "start": {
+                "line": 2,
+                "column": 0
+            },
+            "end": {
+                "line": 4,
+                "column": 24
+            }
+        },
+        "body": [
+            {
+                "type": "VariableDeclaration",
+                "start": 5,
+                "end": 39,
+                "loc": {
+                    "start": {
+                        "line": 2,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 34
+                    }
+                },
+                "declarations": [
+                    {
+                        "type": "VariableDeclarator",
+                        "start": 19,
+                        "end": 38,
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 14
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 33
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "start": 19,
+                            "end": 20,
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 15
+                                }
+                            },
+                            "name": "t"
+                        },
+                        "init": {
+                            "type": "StringLiteral",
+                            "start": 31,
+                            "end": 38,
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 33
+                                }
+                            },
+                            "value": "hello",
+                            "raw": "'hello'",
+                            "leadingComments": [
+                                {
+                                    "type": "CommentBlock",
+                                    "value": " c ",
+                                    "start": 23,
+                                    "end": 30,
+                                    "range": [
+                                        23,
+                                        30
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 18
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 25
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "leadingComments": [
+                            {
+                                "type": "CommentBlock",
+                                "value": " b ",
+                                "start": 11,
+                                "end": 18,
+                                "range": [
+                                    11,
+                                    18
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 6
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 13
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "kind": "const"
+            },
+            {
+                "type": "VariableDeclaration",
+                "start": 41,
+                "end": 65,
+                "loc": {
+                    "start": {
+                        "line": 4,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 24
+                    }
+                },
+                "declarations": [
+                    {
+                        "type": "VariableDeclarator",
+                        "start": 47,
+                        "end": 64,
+                        "loc": {
+                            "start": {
+                                "line": 4,
+                                "column": 6
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 23
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "start": 47,
+                            "end": 52,
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 6
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 11
+                                }
+                            },
+                            "name": "thing"
+                        },
+                        "init": {
+                            "type": "ArrayExpression",
+                            "start": 55,
+                            "end": 64,
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 23
+                                }
+                            },
+                            "elements": [],
+                            "innerComments": [
+                                {
+                                    "type": "CommentBlock",
+                                    "value": " d ",
+                                    "start": 56,
+                                    "end": 63,
+                                    "range": [
+                                        56,
+                                        63
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 15
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 22
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "kind": "const"
+            }
+        ],
+        "sourceType": "script",
+        "directives": []
+    },
+    "comments": [
+        {
+            "type": "CommentLine",
+            "value": " a",
+            "start": 0,
+            "end": 4,
+            "range": [
+                0,
+                4
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 4
+                }
+            }
+        },
+        {
+            "type": "CommentBlock",
+            "value": " b ",
+            "start": 11,
+            "end": 18,
+            "range": [
+                11,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 6
+                },
+                "end": {
+                    "line": 2,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "CommentBlock",
+            "value": " c ",
+            "start": 23,
+            "end": 30,
+            "range": [
+                23,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 18
+                },
+                "end": {
+                    "line": 2,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "CommentBlock",
+            "value": " d ",
+            "start": 56,
+            "end": 63,
+            "range": [
+                56,
+                63
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 15
+                },
+                "end": {
+                    "line": 4,
+                    "column": 22
+                }
+            }
+        }
+    ]
+}

--- a/test/fixture/comments-attached.json
+++ b/test/fixture/comments-attached.json
@@ -3,75 +3,75 @@
     "program": {
         "type": "Program",
         "start": 0,
-        "end": 66,
+        "end": 113,
         "loc": {
             "start": {
                 "line": 2,
-                "column": 0
+                "column": 8
             },
             "end": {
-                "line": 4,
+                "line": 6,
                 "column": 24
             }
         },
         "body": [
             {
                 "type": "VariableDeclaration",
-                "start": 5,
-                "end": 39,
+                "start": 13,
+                "end": 55,
                 "loc": {
                     "start": {
                         "line": 2,
-                        "column": 0
+                        "column": 8
                     },
                     "end": {
                         "line": 2,
-                        "column": 34
+                        "column": 50
                     }
                 },
                 "declarations": [
                     {
                         "type": "VariableDeclarator",
-                        "start": 19,
-                        "end": 38,
+                        "start": 27,
+                        "end": 46,
                         "loc": {
                             "start": {
                                 "line": 2,
-                                "column": 14
+                                "column": 22
                             },
                             "end": {
                                 "line": 2,
-                                "column": 33
+                                "column": 41
                             }
                         },
                         "id": {
                             "type": "Identifier",
-                            "start": 19,
-                            "end": 20,
+                            "start": 27,
+                            "end": 28,
                             "loc": {
                                 "start": {
                                     "line": 2,
-                                    "column": 14
+                                    "column": 22
                                 },
                                 "end": {
                                     "line": 2,
-                                    "column": 15
+                                    "column": 23
                                 }
                             },
                             "name": "t"
                         },
                         "init": {
                             "type": "StringLiteral",
-                            "start": 31,
-                            "end": 38,
+                            "start": 39,
+                            "end": 46,
                             "loc": {
                                 "start": {
                                     "line": 2,
-                                    "column": 26
+                                    "column": 34
                                 },
                                 "end": {
                                     "line": 2,
-                                    "column": 33
+                                    "column": 41
                                 }
                             },
                             "value": "hello",
@@ -79,21 +79,21 @@
                             "leadingComments": [
                                 {
                                     "type": "CommentBlock",
-                                    "value": " c ",
-                                    "start": 23,
-                                    "end": 30,
+                                    "value": " d ",
+                                    "start": 31,
+                                    "end": 38,
                                     "range": [
-                                        23,
-                                        30
+                                        31,
+                                        38
                                     ],
                                     "loc": {
                                         "start": {
                                             "line": 2,
-                                            "column": 18
+                                            "column": 26
                                         },
                                         "end": {
                                             "line": 2,
-                                            "column": 25
+                                            "column": 33
                                         }
                                     }
                                 }
@@ -102,33 +102,55 @@
                         "leadingComments": [
                             {
                                 "type": "CommentBlock",
-                                "value": " b ",
-                                "start": 11,
-                                "end": 18,
+                                "value": " c ",
+                                "start": 19,
+                                "end": 26,
                                 "range": [
-                                    11,
-                                    18
+                                    19,
+                                    26
                                 ],
                                 "loc": {
                                     "start": {
                                         "line": 2,
-                                        "column": 6
+                                        "column": 14
                                     },
                                     "end": {
                                         "line": 2,
-                                        "column": 13
+                                        "column": 21
                                     }
                                 }
                             }
                         ]
                     }
                 ],
-                "kind": "const"
+                "kind": "const",
+                "trailingComments": [
+                    {
+                        "type": "CommentBlock",
+                        "value": " e ",
+                        "start": 47,
+                        "end": 54,
+                        "range": [
+                            47,
+                            54
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 42
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 49
+                            }
+                        }
+                    }
+                ]
             },
             {
                 "type": "VariableDeclaration",
-                "start": 41,
-                "end": 65,
+                "start": 62,
+                "end": 86,
                 "loc": {
                     "start": {
                         "line": 4,
@@ -142,8 +164,8 @@
                 "declarations": [
                     {
                         "type": "VariableDeclarator",
-                        "start": 47,
-                        "end": 64,
+                        "start": 68,
+                        "end": 85,
                         "loc": {
                             "start": {
                                 "line": 4,
@@ -156,8 +178,8 @@
                         },
                         "id": {
                             "type": "Identifier",
-                            "start": 47,
-                            "end": 52,
+                            "start": 68,
+                            "end": 73,
                             "loc": {
                                 "start": {
                                     "line": 4,
@@ -172,8 +194,8 @@
                         },
                         "init": {
                             "type": "ArrayExpression",
-                            "start": 55,
-                            "end": 64,
+                            "start": 76,
+                            "end": 85,
                             "loc": {
                                 "start": {
                                     "line": 4,
@@ -188,12 +210,12 @@
                             "innerComments": [
                                 {
                                     "type": "CommentBlock",
-                                    "value": " d ",
-                                    "start": 56,
-                                    "end": 63,
+                                    "value": " g ",
+                                    "start": 77,
+                                    "end": 84,
                                     "range": [
-                                        56,
-                                        63
+                                        77,
+                                        84
                                     ],
                                     "loc": {
                                         "start": {
@@ -202,6 +224,115 @@
                                         },
                                         "end": {
                                             "line": 4,
+                                            "column": 22
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "kind": "const",
+                "leadingComments": [
+                    {
+                        "type": "CommentLine",
+                        "value": " f",
+                        "start": 56,
+                        "end": 60,
+                        "range": [
+                            56,
+                            60
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 51
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 55
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "type": "VariableDeclaration",
+                "start": 88,
+                "end": 112,
+                "loc": {
+                    "start": {
+                        "line": 6,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 24
+                    }
+                },
+                "declarations": [
+                    {
+                        "type": "VariableDeclarator",
+                        "start": 94,
+                        "end": 111,
+                        "loc": {
+                            "start": {
+                                "line": 6,
+                                "column": 6
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 23
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "start": 94,
+                            "end": 99,
+                            "loc": {
+                                "start": {
+                                    "line": 6,
+                                    "column": 6
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 11
+                                }
+                            },
+                            "name": "other"
+                        },
+                        "init": {
+                            "type": "ObjectExpression",
+                            "start": 102,
+                            "end": 111,
+                            "loc": {
+                                "start": {
+                                    "line": 6,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 23
+                                }
+                            },
+                            "properties": [],
+                            "innerComments": [
+                                {
+                                    "type": "CommentBlock",
+                                    "value": " h ",
+                                    "start": 103,
+                                    "end": 110,
+                                    "range": [
+                                        103,
+                                        110
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 15
+                                        },
+                                        "end": {
+                                            "line": 6,
                                             "column": 22
                                         }
                                     }
@@ -240,51 +371,111 @@
         {
             "type": "CommentBlock",
             "value": " b ",
-            "start": 11,
-            "end": 18,
+            "start": 5,
+            "end": 12,
             "range": [
-                11,
-                18
+                5,
+                12
             ],
             "loc": {
                 "start": {
                     "line": 2,
-                    "column": 6
+                    "column": 0
                 },
                 "end": {
                     "line": 2,
-                    "column": 13
+                    "column": 7
                 }
             }
         },
         {
             "type": "CommentBlock",
             "value": " c ",
-            "start": 23,
-            "end": 30,
+            "start": 19,
+            "end": 26,
             "range": [
-                23,
-                30
+                19,
+                26
             ],
             "loc": {
                 "start": {
                     "line": 2,
-                    "column": 18
+                    "column": 14
                 },
                 "end": {
                     "line": 2,
-                    "column": 25
+                    "column": 21
                 }
             }
         },
         {
             "type": "CommentBlock",
             "value": " d ",
+            "start": 31,
+            "end": 38,
+            "range": [
+                31,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 26
+                },
+                "end": {
+                    "line": 2,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "CommentBlock",
+            "value": " e ",
+            "start": 47,
+            "end": 54,
+            "range": [
+                47,
+                54
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 42
+                },
+                "end": {
+                    "line": 2,
+                    "column": 49
+                }
+            }
+        },
+        {
+            "type": "CommentLine",
+            "value": " f",
             "start": 56,
-            "end": 63,
+            "end": 60,
             "range": [
                 56,
-                63
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 51
+                },
+                "end": {
+                    "line": 2,
+                    "column": 55
+                }
+            }
+        },
+        {
+            "type": "CommentBlock",
+            "value": " g ",
+            "start": 77,
+            "end": 84,
+            "range": [
+                77,
+                84
             ],
             "loc": {
                 "start": {
@@ -293,6 +484,26 @@
                 },
                 "end": {
                     "line": 4,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "CommentBlock",
+            "value": " h ",
+            "start": 103,
+            "end": 110,
+            "range": [
+                103,
+                110
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 15
+                },
+                "end": {
+                    "line": 6,
                     "column": 22
                 }
             }

--- a/test/fixture/comments.json
+++ b/test/fixture/comments.json
@@ -87,7 +87,7 @@
     },
     "comments": [
         {
-            "type": "Line",
+            "type": "CommentLine",
             "value": " declare t",
             "start": 0,
             "end": 12,


### PR DESCRIPTION
This change fixes semistandard estree comments: estree typically uses `Block`,
`Line`, whereas Babel uses `CommentBlock`, `CommentLine`.

This also adds support for attached comments: some estree parsers only support
top-level comments on `Program`, others support only attached comments (recast).
Babel supports both.
So, if either or both are provided, `estree-to-babel` to handles whichever is
given.

Closes GH-3.