### PR TITLE
fix: rename stype to type

### DIFF
--- a/lib/convert-chain-expression.js
+++ b/lib/convert-chain-expression.js
@@ -5,7 +5,7 @@ module.exports = (path) => {
     const {expression} = path.node;
     
     if (expressionPath.isCallExpression())
-        expression.stype = 'OptionalCallExpression';
+        expression.type = 'OptionalCallExpression';
     else
         expression.type = 'OptionalMemberExpression';
     

--- a/test/fixture/chain-expression.json
+++ b/test/fixture/chain-expression.json
@@ -162,7 +162,7 @@
                             "name": "baz"
                         },
                         "init": {
-                            "type": "CallExpression",
+                            "type": "OptionalCallExpression",
                             "start": 34,
                             "end": 41,
                             "loc": {
@@ -193,7 +193,6 @@
                             },
                             "arguments": [],
                             "optional": true,
-                            "stype": "OptionalCallExpression",
                             "trailingComments": [],
                             "leadingComments": [],
                             "innerComments": []


### PR DESCRIPTION
found a typo that results in an invalid ast for optional call expressions (`foo?.();`)

btw have you considered writing your projects in typescript, and validating against the real babel ast (`@babel/types/lib/builders/validateNode` or `t.jsonEqual(result, babelAst)`)? it would prevent bugs like these