### PR TITLE
feat: set directives

### DIFF
--- a/lib/estree-to-babel.js
+++ b/lib/estree-to-babel.js
@@ -10,6 +10,7 @@ const traverseObjectExpression = require('./traverse-object-expression');
 const setClassMethod = require('./set-class-method');
 const setClassPrivateProperty = require('./set-class-private-property');
 const setClassPrivateName = require('./set-class-private-name');
+const setDirectives = require('./set-directives');
 const convertImportToCall = require('./convert-import-to-call');
 const convertChainExpression = require('./convert-chain-expression');
 const convertImportDeclaration = require('./convert-import-declaration');
@@ -40,6 +41,9 @@ module.exports = (node) => {
                 setLiteral(node);
                 return setEsprimaRaw(node);
             }
+            
+            if (type === 'BlockStatement')
+                return setDirectives(node);
             
             if (type === 'Property')
                 return setObjectProperty(node);

--- a/lib/estree-to-babel.js
+++ b/lib/estree-to-babel.js
@@ -42,8 +42,8 @@ module.exports = (node) => {
                 return setEsprimaRaw(node);
             }
             
-            if (type === 'BlockStatement')
-                return setDirectives(node);
+            if (type === 'BlockStatement' || type === 'Program')
+                return setDirectives(path);
             
             if (type === 'Property')
                 return setObjectProperty(node);

--- a/lib/set-directives.js
+++ b/lib/set-directives.js
@@ -1,7 +1,30 @@
 'use strict';
 
-module.exports = (node) => {
+const {
+    Directive,
+    DirectiveLiteral,
+} = require('@babel/types');
+
+module.exports = (path) => {
+    const {node} = path;
+    
     if (!node.directives) {
         node.directives = [];
+    }
+    
+    for (const statementPath of path.get('body')) {
+        if (statementPath.type !== 'ExpressionStatement')
+            continue;
+        
+        const statement = statementPath.node;
+        
+        if (!('directive' in statement))
+            continue;
+        
+        const directiveLiteral = DirectiveLiteral(statement.directive);
+        const directive = Directive(directiveLiteral);
+        
+        node.directives.push(directive);
+        statementPath.remove();
     }
 };

--- a/lib/set-directives.js
+++ b/lib/set-directives.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = (node) => {
+    if (!node.directives) {
+        node.directives = [];
+    }
+};

--- a/test/fixture/class-method.json
+++ b/test/fixture/class-method.json
@@ -198,7 +198,8 @@
                                             "optional": false
                                         }
                                     }
-                                ]
+                                ],
+                                "directives": []
                             },
                             "computed": false,
                             "static": false,

--- a/test/fixture/class-private-method.json
+++ b/test/fixture/class-private-method.json
@@ -232,7 +232,8 @@
                                             "optional": false
                                         }
                                     }
-                                ]
+                                ],
+                                "directives": []
                             },
                             "static": false,
                             "trailingComments": [],

--- a/test/fixture/class-private-method.json
+++ b/test/fixture/class-private-method.json
@@ -255,7 +255,8 @@
                     ]
                 }
             }
-        ]
+        ],
+        "directives": []
     },
     "comments": []
 }

--- a/test/fixture/object-method.json
+++ b/test/fixture/object-method.json
@@ -280,7 +280,8 @@
                                                     "optional": false
                                                 }
                                             }
-                                        ]
+                                        ],
+                                        "directives": []
                                     },
                                     "computed": false,
                                     "generator": false,
@@ -405,7 +406,8 @@
                                                 "column": 26
                                             }
                                         },
-                                        "body": []
+                                        "body": [],
+                                        "directives": []
                                     },
                                     "computed": false,
                                     "generator": false,

--- a/test/fixture/strict-mode.json
+++ b/test/fixture/strict-mode.json
@@ -31,42 +31,6 @@
         "interpreter": null,
         "body": [
             {
-                "type": "ExpressionStatement",
-                "start": 0,
-                "end": 13,
-                "loc": {
-                    "start": {
-                        "line": 1,
-                        "column": 0
-                    },
-                    "end": {
-                        "line": 1,
-                        "column": 13
-                    }
-                },
-                "expression": {
-                    "type": "StringLiteral",
-                    "start": 0,
-                    "end": 12,
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 12
-                        }
-                    },
-                    "value": "use strict",
-                    "raw": "'use strict'",
-                    "extra": {
-                        "raw": "'use strict'"
-                    }
-                },
-                "directive": "use strict"
-            },
-            {
                 "type": "ClassDeclaration",
                 "start": 15,
                 "end": 79,
@@ -289,6 +253,16 @@
                             "generator": false
                         }
                     ]
+                }
+            }
+        ],
+        "directives": [
+            {
+                "type": "Directive",
+                "value": {
+                    "type": "DirectiveLiteral",
+                    "value": "use strict",
+                    "extra": {}
                 }
             }
         ]

--- a/test/fixture/strict-mode.json
+++ b/test/fixture/strict-mode.json
@@ -268,7 +268,8 @@
                                             "optional": false
                                         }
                                     }
-                                ]
+                                ],
+                                "directives": []
                             },
                             "static": false,
                             "trailingComments": [],

--- a/test/fixture/string-literal.json
+++ b/test/fixture/string-literal.json
@@ -351,7 +351,8 @@
                                             "optional": false
                                         }
                                     }
-                                ]
+                                ],
+                                "directives": []
                             }
                         }
                     ],

--- a/test/fixture/ts-private-identifier.json
+++ b/test/fixture/ts-private-identifier.json
@@ -71,7 +71,8 @@
                                             }
                                         }
                                     }
-                                ]
+                                ],
+                                "directives": []
                             },
                             "computed": false,
                             "static": false,


### PR DESCRIPTION
since its a required property of block statements according to the [babel ast spec](https://github.com/babel/babel/blob/main/packages/babel-parser/ast/spec.md#blockstatement)

i noticed that there was already a directives feature in previous commits but it got removed... why?

should be the last pr for now ^^