### PR TITLE
fix: fix TypeScript exports

### DIFF
--- a/lib/estree-to-babel.d.ts
+++ b/lib/estree-to-babel.d.ts
@@ -1,3 +1,5 @@
 import {ParseResult, types} from '@putout/babel';
 
-export default function toBabel(ast: types.Node, src?: string): ParseResult<types.File>;
+declare function toBabel(ast: types.Node, src?: string): ParseResult<types.File>;
+
+export = toBabel;


### PR DESCRIPTION
The package uses `module.exports =` to define exports. The correct way to write types for this is using `export =`. The old `export default` syntax described the property `module.exports.default` instead.