### PR TITLE
Fix export types

### DIFF
--- a/lib/estree-to-babel.d.ts
+++ b/lib/estree-to-babel.d.ts
@@ -1,4 +1,3 @@
 import {ParseResult, types} from '@putout/babel';
 
-declare function toBabel(ast: types.Node, src?: string): ParseResult<types.File>;
-export = toBabel;
+export function toBabel(ast: types.Node, src?: string): ParseResult<types.File>;

--- a/lib/estree-to-babel.d.ts
+++ b/lib/estree-to-babel.d.ts
@@ -1,3 +1,4 @@
 import {ParseResult, types} from '@putout/babel';
 
 export function toBabel(ast: types.Node, src?: string): ParseResult<types.File>;
+

--- a/lib/estree-to-babel.d.ts
+++ b/lib/estree-to-babel.d.ts
@@ -1,4 +1,4 @@
 import {ParseResult, types} from '@putout/babel';
 
-export function toBabel(ast: types.Node, src?: string): ParseResult<types.File>;
+export function estreeToBabel(ast: types.Node, src?: string): ParseResult<types.File>;
 

--- a/test/estree-to-babel.errors.ts
+++ b/test/estree-to-babel.errors.ts
@@ -1,4 +1,5 @@
 import {toBabel} from '..';
+
 // THROWS Expected 1-2 arguments, but got 0.
 toBabel();
 // THROWS Argument of type 'number' is not assignable to parameter of type 'Node'.

--- a/test/estree-to-babel.errors.ts
+++ b/test/estree-to-babel.errors.ts
@@ -1,4 +1,4 @@
-import {toBabel} from '..';
+import {estreeToBabel} from '..';
 
 // THROWS Expected 1-2 arguments, but got 0.
 toBabel();

--- a/test/estree-to-babel.errors.ts
+++ b/test/estree-to-babel.errors.ts
@@ -1,4 +1,4 @@
-import toBabel = require('..');
+import {toBabel} from '..';
 // THROWS Expected 1-2 arguments, but got 0.
 toBabel();
 // THROWS Argument of type 'number' is not assignable to parameter of type 'Node'.

--- a/test/estree-to-babel.errors.ts
+++ b/test/estree-to-babel.errors.ts
@@ -1,5 +1,3 @@
-import {estreeToBabel} from '..';
-
 // THROWS Expected 1-2 arguments, but got 0.
 toBabel();
 // THROWS Argument of type 'number' is not assignable to parameter of type 'Node'.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
+    "exclude": ["test/fixture"],
     "compilerOptions": {
         "module": "node18",
+        "moduleResolution": "node16",
+        "skipLibCheck": true,
         "strict": true,
         "verbatimModuleSyntax": true
     }


### PR DESCRIPTION
Version 11 migrated to ESM with a named export. This was not reflected by the types, now it is.

I also had to add some workarounds for bugs in `@putout/babel`, `madrun`, and test fixtures.

Closes #17